### PR TITLE
Issue 75 Screen titles are cut off on Android

### DIFF
--- a/src/navigation/MainStackNavigator.tsx
+++ b/src/navigation/MainStackNavigator.tsx
@@ -1,6 +1,7 @@
 /* istanbul ignore file */
 
 import React from "react";
+import { Platform } from "react-native";
 import { createStackNavigator, NavigationScreenProps } from "react-navigation";
 
 import { HeaderIconButton } from "../components/HeaderIconButton";
@@ -73,6 +74,17 @@ export default createStackNavigator(
 
     // stack config
     {
+        defaultNavigationOptions: {
+            headerTitleStyle: {
+                ...Platform.select({
+                    android: {
+                        fontFamily: "Roboto"
+                    },
+                    ios: {}
+                })
+            }
+        },
+
         initialRouteName: "Home",
 
         initialRouteParams: {


### PR DESCRIPTION
Ready to be tested on Android. Default font on some phones causes the bug (emulator was fine but OnePlus has the bug). Switching font to Roboto fixed it.